### PR TITLE
Add Twitch webhook integration and Railway docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,9 +1,15 @@
 # optional, uncomment if you are using openAI
-# OPENAI_API_KEY=sk-*** 
+# OPENAI_API_KEY=sk-***
 
 # other options: replicate_llama, openai
-LLM_MODEL=ollama 
+LLM_MODEL=ollama
 
 OLLAMA_URL=http://localhost:11434
 SUPABASE_URL=http://localhost:54321
-SUPABASE_PRIVATE_KEY=*** 
+SUPABASE_PRIVATE_KEY=***
+
+# Twitch integration
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+TWITCH_CHANNEL_ID=
+TWITCH_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ supabase status
 ```
 
 Copy `service_role key` and save it as `SUPABASE_PRIVATE_KEY` in `.env.local`
+Add your Twitch credentials (`TWITCH_CLIENT_ID`, `TWITCH_CLIENT_SECRET`, `TWITCH_CHANNEL_ID`, and `TWITCH_WEBHOOK_SECRET`) to `.env.local` if you plan to use Twitch integration.
+
 
 ### 6. Set up Inngest
 `npx inngest-cli@latest dev`
@@ -151,6 +153,12 @@ This will make sure no one user calls any API too many times and taking up all t
 - Create a new file `.env.prod` locally and fill in all the production-environment secrets. Remember to update `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` by copying secrets from Clerk's production instance -`cat .env.prod | fly secrets import` to upload secrets.
 
 If you have questions, join [AI Stack devs](https://discord.gg/TsWCNVvRP5) and find me in #ai-tamago channel.
+### Deploying on Railway
+1. Install the Railway CLI and run `railway init` in this project.
+2. Add all env variables from `.env.local.example` in the Railway dashboard.
+3. Set `TWITCH_WEBHOOK_SECRET` to the same value used when creating your EventSub subscription.
+4. Deploy with `railway up` and set your Twitch webhook callback URL to `https://<your-app>.up.railway.app/api/twitch/webhook`.
+
 
 ## Other Resources 
 - [Adding auth with Clerk](https://clerk.com/docs/quickstarts/nextjs) - takes < 5mins

--- a/src/app/api/twitch/webhook/route.ts
+++ b/src/app/api/twitch/webhook/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { verifyTwitchSignature, mapEventToInteraction, TwitchEvent } from "@/app/utils/twitch";
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const secret = process.env.TWITCH_WEBHOOK_SECRET!;
+
+  if (!verifyTwitchSignature(req.headers, body, secret)) {
+    return new NextResponse("invalid signature", { status: 401 });
+  }
+
+  const messageType = req.headers.get("Twitch-Eventsub-Message-Type");
+  if (messageType === "webhook_callback_verification") {
+    const data = JSON.parse(body);
+    return NextResponse.json(data.challenge);
+  }
+
+  if (messageType === "notification") {
+    const event = JSON.parse(body) as TwitchEvent;
+    const interaction = mapEventToInteraction(event);
+    if (interaction !== null) {
+      await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ""}/api/interact`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ interactionType: interaction }),
+      });
+    }
+  }
+
+  return NextResponse.json({});
+}

--- a/src/app/utils/twitch.ts
+++ b/src/app/utils/twitch.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto";
+import { INTERACTION } from "./interaction";
+export function verifyTwitchSignature(headers: Headers, body: string, secret: string): boolean {
+  const messageId = headers.get('Twitch-Eventsub-Message-Id');
+  const timestamp = headers.get('Twitch-Eventsub-Message-Timestamp');
+  const signature = headers.get('Twitch-Eventsub-Message-Signature');
+  if (!messageId || !timestamp || !signature) return false;
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(messageId + timestamp + body);
+  const expected = 'sha256=' + hmac.digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+
+export interface TwitchEvent {
+  subscription: { type: string };
+  event: any;
+}
+
+export function mapEventToInteraction(evt: TwitchEvent): number | null {
+  if (evt.subscription.type === 'channel.channel_points_custom_reward_redemption.add') {
+    const title = evt.event.reward.title.toLowerCase();
+    if (title.includes('feed')) return INTERACTION.FEED;
+    if (title.includes('play')) return INTERACTION.PLAY;
+    if (title.includes('clean') || title.includes('bath')) return INTERACTION.BATH;
+    if (title.includes('discipline')) return INTERACTION.DISCIPLINE;
+    if (title.includes('hospital') || title.includes('heal')) return INTERACTION.GO_TO_HOSPITAL;
+  }
+  if (evt.subscription.type === 'channel.cheer') {
+    const bits = evt.event.bits ?? 0;
+    if (bits >= 1000) return INTERACTION.GO_TO_HOSPITAL;
+    if (bits >= 500) return INTERACTION.BATH;
+    if (bits >= 100) return INTERACTION.PLAY;
+    return INTERACTION.FEED;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add Twitch EventSub webhook handling
- map bits and channel point redemptions to Tamagotchi interactions
- document Twitch env vars and Railway deployment

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688cb883de68832599145c641eaa5895